### PR TITLE
Fix redundant label in check vaccine avail dropdown

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -95,7 +95,7 @@ export default function Form({ onSubmit, onChange, formData }) {
           <option value="day">Every day</option>
           <option value="12">Every 12 hours</option>
           <option value="6">Every 6 hours</option>
-          <option value="4">Every 6 hours</option>
+          <option value="4">Every 4 hours</option>
           <option value="2">Every 2 hours</option>
         </select>
       </div>


### PR DESCRIPTION
A small fix to update duplicate option description of 'Every 6 hours'

![image](https://user-images.githubusercontent.com/21218732/116807375-8ca09680-ab50-11eb-8141-7a2094e43879.png)
